### PR TITLE
Use /scratch dir for tests

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -10,6 +10,12 @@ export CATTLE_TEST_AGENT_IMAGE PHANTOMJS_BIN
 
 cd $(dirname $0)/..
 
+if [ -d '/scratch' ]; then
+    rm -rf /scratch/*
+    rsync -a --delete ./ /scratch
+    cd /scratch
+fi
+
 build_env()
 {
     ./scripts/build-env 


### PR DESCRIPTION
When running the tests inside a container, it will fail because
the bind mount doesn't allow tox to create hard links. This update
makes use of the /scratch directory added to the DIND containers that
we run CI from.