### PR TITLE
Add tty+stdin container options for the test container deployed

### DIFF
--- a/tests/validation/cattlevalidationtest/core/test_cluster.py
+++ b/tests/validation/cattlevalidationtest/core/test_cluster.py
@@ -87,7 +87,9 @@ def test_cluster_add_remove_host(client, test_name, managed_network,
             name=test_name + "-cl-deployed",
             networkIds=[managed_network.id],
             imageUuid='docker:ubuntu',
-            requestedHostId=cluster.id)
+            requestedHostId=cluster.id,
+            tty=True,
+            stdinOpen=True)
         wait_for_condition(
             client, test_container,
             lambda x: x.state == 'running',


### PR DESCRIPTION
Add tty+stdin container options for the test container deployed to the cluster so it doesn't exit immediately.