### PR TITLE
Use label for RANCHER_NETWORK

### DIFF
--- a/tests/validation/cattlevalidationtest/core/common_fixtures.py
+++ b/tests/validation/cattlevalidationtest/core/common_fixtures.py
@@ -480,7 +480,7 @@ def get_docker_client(host):
 
     params = {}
     params['base_url'] = 'tcp://%s:%s' % (ip, port)
-    api_version = os.getenv('DOCKER_API_VERSION', '1.15')
+    api_version = os.getenv('DOCKER_API_VERSION', '1.18')
     params['version'] = api_version
 
     return Client(**params)

--- a/tests/validation/cattlevalidationtest/core/test_native_docker.py
+++ b/tests/validation/cattlevalidationtest/core/test_native_docker.py
@@ -92,7 +92,7 @@ def test_native_managed_network(socat_containers, client, native_name,
     d_container = docker_client. \
         create_container(NATIVE_TEST_IMAGE,
                          name=native_name,
-                         environment=['RANCHER_NETWORK=true'])
+                         labels={'io.rancher.container.network': 'true'})
     docker_client.start(d_container)
     inspect = docker_client.inspect_container(d_container)
 
@@ -217,7 +217,7 @@ def test_native_ip_inject(client, socat_containers, native_name,
     d_container = docker_client. \
         create_container(NATIVE_TEST_IMAGE,
                          name=native_name,
-                         environment=['RANCHER_NETWORK=true'],
+                         labels={'io.rancher.container.network': 'true'},
                          tty=True,
                          stdin_open=True,
                          detach=True,

--- a/tests/validation/requirements.txt
+++ b/tests/validation/requirements.txt
@@ -5,5 +5,5 @@ requests==2.6.0
 cattle==0.5.1
 selenium
 websocket-client==0.23.0
-docker-py
+docker-py==1.2.2
 boto


### PR DESCRIPTION
Update native_docker tests to use docker labels when creating a non-rancher container that should use the rancher network.

***Dont merge. This requires some coordination because it requires that we upgrade to 1.6.***
I'll coordinate with @ibuildthecloud and @cloudnautique on when it can be merged.