### PR TITLE
Added privileged flag to socat container for Fedora

### DIFF
--- a/tests/validation/cattlevalidationtest/core/common_fixtures.py
+++ b/tests/validation/cattlevalidationtest/core/common_fixtures.py
@@ -458,6 +458,7 @@ def socat_containers(client, request):
             stdinOpen=False,
             tty=False,
             publishAllPorts=True,
+            privileged=True,
             dataVolumes='/var/run/docker.sock:/var/run/docker.sock',
             requestedHostId=host.id)
         socat_container_list.append(socat_container)


### PR DESCRIPTION
When bind mounting the docker.sock file in Fedora you need to be privileged.