### PR TITLE
Included deletion of instances that are no more part of services, socat containers and adjusted the format for instance names to have 1-6 numeric characters.

### DIFF
--- a/tests/validation/cattlevalidationtest/core/common_fixtures.py
+++ b/tests/validation/cattlevalidationtest/core/common_fixtures.py
@@ -43,20 +43,12 @@ def cattle_url():
 
 @pytest.fixture(autouse=True, scope='session')
 def cleanup(super_client):
-    to_delete = []
-
-    instance_name_format = re.compile('test-[0-9]{6}')
-    env_name_format = re.compile('test[0-9]{6}')
-
-    for i in super_client.list_instance(state='running'):
-        try:
-            if instance_name_format.match(i.name):
-
-                to_delete.append(i)
-        except AttributeError:
-            pass
-
-    delete_all(super_client, to_delete)
+    instance_name_format = re.compile('test-[0-9]{1,6}')
+    # For cleaning up environment and instances that get disassociated
+    # from services where deleted
+    env_name_format = re.compile('test[0-9]{1,6}')
+    instance_name_format_for_services = \
+        re.compile('test[0-9]{1,6}_test[0-9]{1,6}_[0-9]*')
 
     to_delete_env = []
     for i in super_client.list_environment(state='active'):
@@ -66,6 +58,31 @@ def cleanup(super_client):
         except AttributeError:
             pass
     delete_all(super_client, to_delete_env)
+
+    to_delete = []
+    for i in super_client.list_instance(state='running'):
+        try:
+            if instance_name_format.match(i.name) or \
+                    instance_name_format_for_services.match(i.name) or \
+                    i.name.startswith("socat"):
+                to_delete.append(i)
+        except AttributeError:
+            pass
+
+    delete_all(super_client, to_delete)
+
+    to_delete = []
+    for i in super_client.list_instance(state='stopped'):
+        try:
+            if i.name is not None:
+                if instance_name_format.match(i.name) or \
+                        instance_name_format_for_services.match(i.name) or \
+                        i.name.startswith("socat"):
+                    to_delete.append(i)
+        except AttributeError:
+            pass
+
+    delete_all(super_client, to_delete)
 
     to_delete_lb = []
     for i in super_client.list_loadBalancer(state='active'):


### PR DESCRIPTION
@alena1108 @cloudnautique , I have updated the cleanup() method to include deletion of instances that are in stopped state , socat containers and adjusted the format for resource names for deletion to have 1-6 numeric characters