### PR TITLE
Fix native docker lxc, memory, and network tests

### DIFF
--- a/tests/validation/cattlevalidationtest/core/common_fixtures.py
+++ b/tests/validation/cattlevalidationtest/core/common_fixtures.py
@@ -447,7 +447,7 @@ def socat_containers(client, request):
 
     if len(socat_container_list) != 0:
         return
-    hosts = client.list_host(kind='docker', removed_null=True)
+    hosts = client.list_host(kind='docker', removed_null=True, state='active')
 
     for host in hosts:
         socat_container = client.create_container(

--- a/tests/validation/requirements.txt
+++ b/tests/validation/requirements.txt
@@ -5,5 +5,5 @@ requests==2.6.0
 cattle==0.5.1
 selenium
 websocket-client==0.23.0
-docker-py==1.2.2
+docker-py==1.2.3
 boto


### PR DESCRIPTION
Remove lxc_conf from the native docker test since the driver in Docker
1.7 doesn't support it.

Pass host_config into create_container instead of into start since that
was deprecated in the Docker API and it was cauing memory settings to
be stomped on.

Added busybox to the list of images to pull since we now use it in a
test.