### PR TITLE
Added time out of 20 seconds when trying to wget on the DNS name as part of validation to prevent test cases from hanging for a longtime before they error out.

### DIFF
--- a/tests/validation/cattlevalidationtest/core/test_dns_services.py
+++ b/tests/validation/cattlevalidationtest/core/test_dns_services.py
@@ -393,7 +393,7 @@ def test_dns_consumed_services_deactivate_activate(super_client, client):
     consumed_service = consumed_service.deactivate()
     consumed_service = client.wait_success(consumed_service, 120)
     assert consumed_service.state == "inactive"
-    time.sleep(60)
+    wait_until_instances_get_stopped(super_client, consumed_service)
 
     consumed_service = consumed_service.activate()
     consumed_service = client.wait_success(consumed_service, 120)
@@ -423,7 +423,7 @@ def test_dns_service_deactivate_activate(super_client, client):
     service = service.deactivate()
     service = client.wait_success(service, 120)
     assert service.state == "inactive"
-    time.sleep(60)
+    wait_until_instances_get_stopped(super_client, service)
 
     service = service.activate()
     service = client.wait_success(service, 120)
@@ -457,7 +457,8 @@ def test_dns_deactivate_activate_environment(super_client, client):
     consumed_service = client.wait_success(consumed_service, 120)
     assert consumed_service.state == "inactive"
 
-    time.sleep(60)
+    wait_until_instances_get_stopped(super_client, service)
+    wait_until_instances_get_stopped(super_client, consumed_service)
 
     env = env.activateservices()
     service = client.wait_success(service, 120)
@@ -735,7 +736,6 @@ def test_dns_dns_deactivate_activate(super_client, client):
     dns = dns.deactivate()
     dns = client.wait_success(dns, 120)
     assert dns.state == "inactive"
-    time.sleep(60)
 
     dns = dns.activate()
     dns = client.wait_success(dns, 120)

--- a/tests/validation/cattlevalidationtest/core/test_ext_services_links.py
+++ b/tests/validation/cattlevalidationtest/core/test_ext_services_links.py
@@ -206,7 +206,6 @@ def test_extservice_ext_services_deactivate_activate(super_client, client):
     ext_service = ext_service.deactivate()
     ext_service = client.wait_success(ext_service, 120)
     assert ext_service.state == "inactive"
-    time.sleep(60)
 
     ext_service = ext_service.activate()
     ext_service = client.wait_success(ext_service, 120)
@@ -233,7 +232,7 @@ def test_extservice_service_deactivate_activate(super_client, client):
     service = service.deactivate()
     service = client.wait_success(service, 120)
     assert service.state == "inactive"
-    time.sleep(60)
+    wait_until_instances_get_stopped(super_client, service)
 
     service = service.activate()
     service = client.wait_success(service, 120)
@@ -264,7 +263,7 @@ def test_extservice_deactivate_activate_environment(super_client, client):
     ext_service = client.wait_success(ext_service, 120)
     assert ext_service.state == "inactive"
 
-    time.sleep(60)
+    wait_until_instances_get_stopped(super_client, service)
 
     env = env.activateservices()
     service = client.wait_success(service, 120)

--- a/tests/validation/cattlevalidationtest/core/test_services.py
+++ b/tests/validation/cattlevalidationtest/core/test_services.py
@@ -698,18 +698,3 @@ def get_service_container_list(super_client, service):
         container.append(c)
 
     return container
-
-
-def wait_until_instances_get_stopped(super_client, service, timeout=60):
-    stopped_count = 0
-    start = time.time()
-    while stopped_count != service.scale:
-        time.sleep(.5)
-        container_list = get_service_container_list(super_client, service)
-        stopped_count = 0
-        for con in container_list:
-            if con.state == "stopped":
-                stopped_count = stopped_count + 1
-        if time.time() - start > timeout:
-            raise Exception(
-                'Timed out waiting for instances to get to stopped state')

--- a/tests/validation/cattlevalidationtest/core/test_services_lb.py
+++ b/tests/validation/cattlevalidationtest/core/test_services_lb.py
@@ -316,7 +316,7 @@ def test_lb_services_deactivate_activate_lbservice(super_client, client):
     lb_service = lb_service.deactivate()
     lb_service = client.wait_success(lb_service, 120)
     assert lb_service.state == "inactive"
-    time.sleep(60)
+    wait_until_instances_get_stopped(super_client, lb_service)
 
     lb_service = lb_service.activate()
     lb_service = client.wait_success(lb_service, 120)
@@ -341,7 +341,7 @@ def test_lb_services_deactivate_activate_service(super_client, client):
     service = service.deactivate()
     service = client.wait_success(service, 120)
     assert service.state == "inactive"
-    time.sleep(60)
+    wait_until_instances_get_stopped(super_client, service)
 
     service = service.activate()
     service = client.wait_success(service, 120)
@@ -370,7 +370,7 @@ def test_lb_services_deactivate_activate_environment(super_client, client):
     lb_service = client.wait_success(lb_service, 120)
     assert lb_service.state == "inactive"
 
-    time.sleep(60)
+    wait_until_instances_get_stopped(super_client, lb_service)
 
     env = env.activateservices()
     service = client.wait_success(service, 120)

--- a/tests/validation/cattlevalidationtest/core/test_services_links.py
+++ b/tests/validation/cattlevalidationtest/core/test_services_links.py
@@ -330,7 +330,7 @@ def test_link_consumed_services_deactivate_activate(super_client, client):
     consumed_service = consumed_service.deactivate()
     consumed_service = client.wait_success(consumed_service, 120)
     assert consumed_service.state == "inactive"
-    time.sleep(60)
+    wait_until_instances_get_stopped(super_client, consumed_service)
 
     consumed_service = consumed_service.activate()
     consumed_service = client.wait_success(consumed_service, 120)
@@ -355,7 +355,7 @@ def test_link_service_deactivate_activate(super_client, client):
     service = service.deactivate()
     service = client.wait_success(service, 120)
     assert service.state == "inactive"
-    time.sleep(60)
+    wait_until_instances_get_stopped(super_client, service)
 
     service = service.activate()
     service = client.wait_success(service, 120)
@@ -384,7 +384,7 @@ def test_link_deactivate_activate_environment(super_client, client):
     consumed_service = client.wait_success(consumed_service, 120)
     assert consumed_service.state == "inactive"
 
-    time.sleep(60)
+    wait_until_instances_get_stopped(super_client, consumed_service)
 
     env = env.activateservices()
     service = client.wait_success(service, 120)


### PR DESCRIPTION
Also Added wait for instances of service to be stopped when deactivated instead of waiting for 1 minute.
@alena1108 , can you please review the changes done to add time out of 20 seconds when trying to wget on the DNS name as part of validation to prevent test cases from hanging for a longtime before they error out.